### PR TITLE
Update gatsby-plugin-sass to version that exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gatsby-plugin-manifest": "^2.0.29",
     "gatsby-plugin-offline": "^2.0.25",
     "gatsby-plugin-react-helmet": "^3.0.12",
-    "gatsby-plugin-sass": "^2.0.11",
+    "gatsby-plugin-sass": "^2.2.1",
     "gatsby-plugin-sharp": "^2.0.35",
     "gatsby-source-filesystem": "^2.0.33",
     "gatsby-transformer-sharp": "^2.1.18",


### PR DESCRIPTION
The referenced version of `gatsby-plugin-saas` would not install (gave a `404` error). Set to latest version and now the install succeeds.